### PR TITLE
Add Spring Boot GraphQL dynamic model prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>dynamicmodel</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>dynamicmodel</name>
+    <description>Dynamic model GraphQL API</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-boot.version>3.2.4</spring-boot.version>
+    </properties>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>${spring-boot.version}</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-graphql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java-extended-scalars</artifactId>
+            <version>21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/dynamicmodel/DynamicModelApplication.java
+++ b/src/main/java/com/example/dynamicmodel/DynamicModelApplication.java
@@ -1,0 +1,11 @@
+package com.example.dynamicmodel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DynamicModelApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DynamicModelApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/dynamicmodel/graphql/DynamicEntityController.java
+++ b/src/main/java/com/example/dynamicmodel/graphql/DynamicEntityController.java
@@ -1,0 +1,55 @@
+package com.example.dynamicmodel.graphql;
+
+import com.example.dynamicmodel.model.DynamicEntity;
+import com.example.dynamicmodel.service.DynamicEntityService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.scalars.ExtendedScalars;
+import graphql.schema.GraphQLScalarType;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.Map;
+
+@Controller
+public class DynamicEntityController {
+
+    private final DynamicEntityService service;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public DynamicEntityController(DynamicEntityService service) {
+        this.service = service;
+    }
+
+    @QueryMapping
+    public DynamicEntity entity(@Argument String id, @Argument String type) {
+        return service.findById(id)
+                .filter(e -> type.equals(e.getType()))
+                .orElse(null);
+    }
+
+    @QueryMapping
+    public java.util.List<DynamicEntity> entities(@Argument String type) {
+        return service.findByType(type);
+    }
+
+    @MutationMapping
+    public DynamicEntity createEntity(@Argument String type, @Argument Map<String, Object> attributes) {
+        return service.create(type, attributes);
+    }
+
+    @MutationMapping
+    public DynamicEntity updateEntity(@Argument String id, @Argument String type, @Argument Map<String, Object> attributes) {
+        return service.update(id, type, attributes);
+    }
+
+    @MutationMapping
+    public Boolean deleteEntity(@Argument String id) {
+        return service.delete(id);
+    }
+
+    public GraphQLScalarType jsonScalar() {
+        return ExtendedScalars.Json;
+    }
+}

--- a/src/main/java/com/example/dynamicmodel/model/DynamicEntity.java
+++ b/src/main/java/com/example/dynamicmodel/model/DynamicEntity.java
@@ -1,0 +1,46 @@
+package com.example.dynamicmodel.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Document(collection = "entities")
+public class DynamicEntity {
+    @Id
+    private String id;
+    private String type;
+    private Map<String, Object> attributes = new HashMap<>();
+
+    public DynamicEntity() {}
+
+    public DynamicEntity(String type, Map<String, Object> attributes) {
+        this.type = type;
+        this.attributes = attributes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/src/main/java/com/example/dynamicmodel/repository/DynamicEntityRepository.java
+++ b/src/main/java/com/example/dynamicmodel/repository/DynamicEntityRepository.java
@@ -1,0 +1,9 @@
+package com.example.dynamicmodel.repository;
+
+import com.example.dynamicmodel.model.DynamicEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DynamicEntityRepository extends MongoRepository<DynamicEntity, String> {
+}

--- a/src/main/java/com/example/dynamicmodel/service/DynamicEntityService.java
+++ b/src/main/java/com/example/dynamicmodel/service/DynamicEntityService.java
@@ -1,0 +1,49 @@
+package com.example.dynamicmodel.service;
+
+import com.example.dynamicmodel.model.DynamicEntity;
+import com.example.dynamicmodel.repository.DynamicEntityRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DynamicEntityService {
+
+    private final DynamicEntityRepository repository;
+
+    public DynamicEntityService(DynamicEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    public DynamicEntity create(String type, java.util.Map<String, Object> attributes) {
+        DynamicEntity entity = new DynamicEntity(type, attributes);
+        return repository.save(entity);
+    }
+
+    public Optional<DynamicEntity> findById(String id) {
+        return repository.findById(id);
+    }
+
+    public List<DynamicEntity> findByType(String type) {
+        return repository.findAll().stream()
+                .filter(e -> type.equals(e.getType()))
+                .toList();
+    }
+
+    public DynamicEntity update(String id, String type, java.util.Map<String, Object> attributes) {
+        DynamicEntity entity = repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Entity not found"));
+        entity.setType(type);
+        entity.setAttributes(attributes);
+        return repository.save(entity);
+    }
+
+    public boolean delete(String id) {
+        if (repository.existsById(id)) {
+            repository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  data:
+    mongodb:
+      database: dynamicdb
+      host: localhost
+      port: 27017
+
+  graphql:
+    schema:
+      locations: classpath:graphql/**/schema.graphqls
+

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,18 @@
+type DynamicEntity {
+    id: ID!
+    type: String!
+    attributes: JSON
+}
+
+scalar JSON
+
+type Query {
+    entity(id: ID!, type: String!): DynamicEntity
+    entities(type: String!): [DynamicEntity]
+}
+
+type Mutation {
+    createEntity(type: String!, attributes: JSON!): DynamicEntity
+    updateEntity(id: ID!, type: String!, attributes: JSON!): DynamicEntity
+    deleteEntity(id: ID!): Boolean
+}

--- a/src/test/java/com/example/dynamicmodel/DynamicEntityIntegrationTest.java
+++ b/src/test/java/com/example/dynamicmodel/DynamicEntityIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.example.dynamicmodel;
+
+import com.example.dynamicmodel.model.DynamicEntity;
+import com.example.dynamicmodel.repository.DynamicEntityRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.graphql.test.tester.GraphQlTester;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@GraphQlTest
+class DynamicEntityIntegrationTest {
+
+    @Autowired
+    private GraphQlTester graphQlTester;
+
+    @MockBean
+    private DynamicEntityRepository repository;
+
+    @Test
+    void createAndQueryEntity() {
+        DynamicEntity saved = new DynamicEntity("Client", Map.of("firstname", "John"));
+        saved.setId("1");
+
+        when(repository.save(any(DynamicEntity.class))).thenReturn(saved);
+        when(repository.findById("1")).thenReturn(java.util.Optional.of(saved));
+        when(repository.findAll()).thenReturn(java.util.List.of(saved));
+
+        String mutation = "mutation { createEntity(type: \"Client\", attributes: {firstname: \"John\"}) { id type attributes } }";
+        graphQlTester.document(mutation)
+                .execute()
+                .path("createEntity.type").entity(String.class).isEqualTo("Client");
+
+        String query = "{ entity(id: \"1\", type: \"Client\") { id type attributes } }";
+        graphQlTester.document(query)
+                .execute()
+                .path("entity.id").entity(String.class).isEqualTo("1");
+
+        verify(repository, times(1)).save(any(DynamicEntity.class));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  mongodb:
+    embedded:
+      version: 6.0.5


### PR DESCRIPTION
## Summary
- initialize Maven Spring Boot app
- add generic dynamic entity support
- expose GraphQL CRUD API
- configure embedded Mongo for tests
- add basic GraphQL integration test

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686104ca4bdc832e905d6099a29f212a