### PR TITLE
Add Maven project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Maven build output
+target/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# agentpim
+
+Java/Maven project. See `pom.xml` for build and dependencies (Java 17, JUnit 5, AssertJ).
+
+## Testing conventions
+
+- Test method names follow **Given-When-Then**, e.g. `givenEmptyList_whenSizeCalled_thenReturnsZero()`.
+- Every test body has exactly three sections, in this order, separated by a single blank line:
+  1. Given — setup/initialization
+  2. When — the execution/action under test
+  3. Then — assertions
+- No comments inside test code, ever — not even to label the Given/When/Then sections. The blank lines are the only separators.
+- Use AssertJ for all assertions (`assertThat(...)`), not plain JUnit assertions. Use its richer API where it fits — e.g. `assertThat(list).containsExactly(...)`, `.hasSize(...)`, `.extracting(...)` — instead of asserting on raw sizes or looping manually.
+- No parameterized tests (`@ParameterizedTest`). Write every case out as its own explicit test method.
+- Mock as little as possible. Only introduce a mock (Mockito or otherwise) when a real collaborator can't reasonably be used in the test (e.g. network, filesystem, time, external services). Prefer real objects.
+
+## General coding conventions
+
+- Write genuinely object-oriented code — behavior belongs on objects, not in static helpers operating on data bags.
+- Apply design patterns where they earn their keep. In particular, prefer the **Strategy pattern** over large if-else/switch cascades that branch on type or mode.

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
+        <assertj.version>3.26.3</assertj.version>
     </properties>
 
     <dependencies>
@@ -21,6 +22,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.agentpim</groupId>
+    <artifactId>agentpim</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.agentpim.App</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/agentpim/App.java
+++ b/src/main/java/com/agentpim/App.java
@@ -1,0 +1,7 @@
+package com.agentpim;
+
+public class App {
+    public static void main(String[] args) {
+        System.out.println("Hello from agentpim!");
+    }
+}

--- a/src/test/java/com/agentpim/AppTest.java
+++ b/src/test/java/com/agentpim/AppTest.java
@@ -1,0 +1,13 @@
+package com.agentpim;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class AppTest {
+
+    @Test
+    void mainRunsWithoutError() {
+        assertNotNull(new App());
+    }
+}

--- a/src/test/java/com/agentpim/AppTest.java
+++ b/src/test/java/com/agentpim/AppTest.java
@@ -1,6 +1,6 @@
 package com.agentpim;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +8,6 @@ class AppTest {
 
     @Test
     void mainRunsWithoutError() {
-        assertNotNull(new App());
+        assertThat(new App()).isNotNull();
     }
 }

--- a/src/test/java/com/agentpim/AppTest.java
+++ b/src/test/java/com/agentpim/AppTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test;
 class AppTest {
 
     @Test
-    void mainRunsWithoutError() {
-        assertThat(new App()).isNotNull();
+    void givenNoArguments_whenAppIsConstructed_thenInstanceIsNotNull() {
+        App app = new App();
+
+        assertThat(app).isNotNull();
     }
 }


### PR DESCRIPTION
Sets up a minimal Maven-based Java project (Java 17, JUnit 5) with a
basic App class and test, plus target/ in .gitignore.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hFaEcxJbtL1iPHidztvxQ