### PR TITLE
Java 25 upgrade, simulation core, and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,20 @@ jobs:
       - name: Compile
         run: mvn -B compile
 
+  lint:
+    name: Lint
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: Checkstyle
+        run: mvn -B checkstyle:check
+
   test:
     name: Test
     needs: build
@@ -33,9 +47,23 @@ jobs:
       - name: Run tests
         run: mvn -B test
 
+  dependency-scan:
+    name: Dependency Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+
   package:
     name: Package
-    needs: test
+    needs: [lint, test, dependency-scan]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: Compile
+        run: mvn -B compile
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: Run tests
+        run: mvn -B test
+
+  package:
+    name: Package
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: Build jar
+        run: mvn -B package -DskipTests
+      - name: Upload jar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentpim-jar
+          path: target/agentpim.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # agentpim
 
-Java/Maven project. See `pom.xml` for build and dependencies (Java 17, JUnit 5, AssertJ).
+Java/Maven project. See `pom.xml` for build and dependencies (Java 25, JUnit 5, AssertJ).
 
 ## Testing conventions
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="LineLength">
+        <property name="max" value="120"/>
+    </module>
+    <module name="FileTabCharacter"/>
+
+    <module name="TreeWalker">
+        <module name="UnusedImports"/>
+        <module name="RedundantImport"/>
+        <module name="AvoidStarImport"/>
+        <module name="EqualsHashCode"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="EmptyBlock"/>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="WhitespaceAround"/>
+        <module name="OneTopLevelClass"/>
+        <module name="OuterTypeFilename"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
         <assertj.version>3.26.3</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,17 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <violationSeverity>warning</violationSeverity>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/com/agentpim/simulation/Simulation.java
+++ b/src/main/java/com/agentpim/simulation/Simulation.java
@@ -1,0 +1,40 @@
+package com.agentpim.simulation;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Simulation {
+
+    private final Duration tickDuration;
+    private final List<SimulationEntity> entities = new ArrayList<>();
+    private Duration elapsedTime = Duration.ZERO;
+
+    public Simulation(Duration tickDuration) {
+        if (tickDuration.isZero() || tickDuration.isNegative()) {
+            throw new IllegalArgumentException("tickDuration must be positive: " + tickDuration);
+        }
+
+        this.tickDuration = tickDuration;
+    }
+
+    public void addEntity(SimulationEntity entity) {
+        entities.add(entity);
+    }
+
+    public void tick() {
+        for (SimulationEntity entity : entities) {
+            entity.tick(tickDuration);
+        }
+
+        elapsedTime = elapsedTime.plus(tickDuration);
+    }
+
+    public Duration tickDuration() {
+        return tickDuration;
+    }
+
+    public Duration elapsedTime() {
+        return elapsedTime;
+    }
+}

--- a/src/main/java/com/agentpim/simulation/SimulationEntity.java
+++ b/src/main/java/com/agentpim/simulation/SimulationEntity.java
@@ -1,0 +1,8 @@
+package com.agentpim.simulation;
+
+import java.time.Duration;
+
+public interface SimulationEntity {
+
+    void tick(Duration tickDuration);
+}

--- a/src/test/java/com/agentpim/simulation/RecordingSimulationEntity.java
+++ b/src/test/java/com/agentpim/simulation/RecordingSimulationEntity.java
@@ -1,0 +1,19 @@
+package com.agentpim.simulation;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+class RecordingSimulationEntity implements SimulationEntity {
+
+    private final List<Duration> receivedTickDurations = new ArrayList<>();
+
+    @Override
+    public void tick(Duration tickDuration) {
+        receivedTickDurations.add(tickDuration);
+    }
+
+    List<Duration> receivedTickDurations() {
+        return receivedTickDurations;
+    }
+}

--- a/src/test/java/com/agentpim/simulation/SimulationTest.java
+++ b/src/test/java/com/agentpim/simulation/SimulationTest.java
@@ -1,0 +1,81 @@
+package com.agentpim.simulation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class SimulationTest {
+
+    @Test
+    void givenNewSimulation_whenNoTicksHaveOccurred_thenElapsedTimeIsZero() {
+        Simulation simulation = new Simulation(Duration.ofMillis(100));
+
+        Duration elapsedTime = simulation.elapsedTime();
+
+        assertThat(elapsedTime).isZero();
+    }
+
+    @Test
+    void givenTickDuration_whenTickIsCalledOnce_thenElapsedTimeEqualsTickDuration() {
+        Duration tickDuration = Duration.ofMillis(100);
+        Simulation simulation = new Simulation(tickDuration);
+
+        simulation.tick();
+
+        assertThat(simulation.elapsedTime()).isEqualTo(tickDuration);
+    }
+
+    @Test
+    void givenTickDuration_whenTickIsCalledMultipleTimes_thenElapsedTimeAccumulates() {
+        Duration tickDuration = Duration.ofMillis(100);
+        Simulation simulation = new Simulation(tickDuration);
+
+        simulation.tick();
+        simulation.tick();
+        simulation.tick();
+
+        assertThat(simulation.elapsedTime()).isEqualTo(Duration.ofMillis(300));
+    }
+
+    @Test
+    void givenRegisteredEntity_whenTickIsCalled_thenEntityReceivesTickDuration() {
+        Duration tickDuration = Duration.ofMillis(250);
+        Simulation simulation = new Simulation(tickDuration);
+        RecordingSimulationEntity entity = new RecordingSimulationEntity();
+        simulation.addEntity(entity);
+
+        simulation.tick();
+
+        assertThat(entity.receivedTickDurations()).containsExactly(tickDuration);
+    }
+
+    @Test
+    void givenMultipleRegisteredEntities_whenTickIsCalled_thenAllEntitiesAreTicked() {
+        Duration tickDuration = Duration.ofMillis(50);
+        Simulation simulation = new Simulation(tickDuration);
+        RecordingSimulationEntity firstEntity = new RecordingSimulationEntity();
+        RecordingSimulationEntity secondEntity = new RecordingSimulationEntity();
+        simulation.addEntity(firstEntity);
+        simulation.addEntity(secondEntity);
+
+        simulation.tick();
+        simulation.tick();
+
+        assertThat(firstEntity.receivedTickDurations()).containsExactly(tickDuration, tickDuration);
+        assertThat(secondEntity.receivedTickDurations()).containsExactly(tickDuration, tickDuration);
+    }
+
+    @Test
+    void givenZeroTickDuration_whenSimulationIsConstructed_thenThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> new Simulation(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void givenNegativeTickDuration_whenSimulationIsConstructed_thenThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> new Simulation(Duration.ofMillis(-1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- Upgrades the project to Java 25 (LTS) via `maven.compiler.release`
- Adds a fixed-timestep `Simulation` core (`SimulationEntity` interface, `Simulation` tick loop) as the foundation for the aircraft simulation
- Adds a GitHub Actions CI pipeline with separate stages: build, lint (Checkstyle), test, dependency-scan (Trivy), and package (uploads the built jar as a workflow artifact)

## Test plan
- [x] `mvn clean compile checkstyle:check test package` runs clean locally on JDK 25 (0 Checkstyle violations, all tests pass, jar builds)
- [ ] Confirm the new CI workflow runs green on GitHub Actions once opened as a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hFaEcxJbtL1iPHidztvxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011hFaEcxJbtL1iPHidztvxQ)_